### PR TITLE
feat: add environment setups for python-3.10 and julia-1.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,124 @@
+PYTHON_VERSION := 3.10
+BENCHMARK_DEPS := pytest-benchmark
+VENV_DIR := env/python-env
+
+# Check if virtual environment exists.
+check-env-python:
+	@if [ -d "$(VENV_DIR)" ]; then \
+		echo "Virtual environment already exists at $(VENV_DIR)"; \
+		exit 0; \
+	else \
+		echo "No existing virtual environment found"; \
+		exit 1; \
+	fi
+
+# Setup Python virtual environment.
+setup-python: check-env-python
+	@if [ $$? -eq 1 ]; then \
+		echo "Creating Python $(PYTHON_VERSION) virtual environment..."; \
+		mkdir -p env; \
+		python$(PYTHON_VERSION) -m venv $(VENV_DIR); \
+		echo "Upgrading pip..."; \
+		$(VENV_DIR)/bin/python -m pip install --upgrade pip; \
+		echo "Virtual environment ready"; \
+	fi
+
+# Verify Python environment existence (create if missing).
+ensure-python:
+	@if [ ! -d "$(VENV_DIR)" ]; then \
+		$(MAKE) setup-python; \
+	fi
+
+# Execute Python benchmarks
+test-python: ensure-python
+	@echo "Installing/updating test dependencies..."
+	@$(VENV_DIR)/bin/python -m pip install $(BENCHMARK_DEPS)
+	@echo "Running tests..."
+	@$(VENV_DIR)/bin/python benchmarks/test.py
+	@echo "Tests completed!"
+
+# Remove Python virtual environment.
+clean-python:
+	@echo "Cleaning up Python virtual environment..."
+	@rm -rf $(VENV_DIR)
+	@echo "Environment removed ..."
+
+# Reinstall Python environment.
+reinstall-python: clean-python setup-python
+	@echo "Python $(PYTHON_VERSION) reinstallation complete"
+
+
+JULIA_VERSION := 1.10
+JULIA_DIR := $(HOME)/.julia
+JULIAUP_DIR := $(HOME)/.juliaup
+JULIA_ENV := env/julia-env
+JULIAUP_BIN := $(JULIAUP_DIR)/bin
+
+# Fresh Julia installation procedure.
+install-julia-fresh:
+	@echo "Performing Julia cleanup for fresh installation ... "
+	@rm -rf "$(JULIA_DIR)" "(JULIAUP_DIR)" "$(JULIA_ENV)"
+
+
+	@echo "Installing Julia $(JULIA_VERSION) ..."
+	@curl -fsSL https://install.julialang.org | sh -s -- --yes || (echo "❌ Juliaup installation failed"; exit 1)
+	
+
+	@echo "Verifying juliaup installation ... "
+	@if [ -f "$(JULIAUP_BIN)/juliaup" ]; then \
+		echo "Setting Julia $(JULIA_VERSION) as default ..."; \
+		"$(JULIAUP_BIN)/juliaup" add $(JULIA_VERSION); \
+		"$(JULIAUP_BIN)/juliaup" default $(JULIA_VERSION); \
+	else\
+		echo "Juliaup binary not found !!!"; \
+		exit 1; \
+	fi
+
+
+	@echo "Creating project environment ... "
+	@mkdir -p $(JULIA_ENV)
+	@"$(JULIAUP_BIN)/julia" --project=$(JULIA_ENV) -e "using Pkg; Pkg.add(\"BenchmarkTools\"); Pkg.instantiate()"
+	@echo "Julia $(JULIA_VERSION) setup complete in $(JULIA_ENV)."
+
+
+# Julia environment setup.
+setup-julia:
+	@echo "Checking for existing Julia $(JULIA_VERSION)..."
+	@if command -v julia >/dev/null 2>&1; then \
+		CURRENT_VERSION=$$(julia --version 2>/dev/null | sed -n 's/julia version \([0-9]\+\.[0-9]\+\).*/\1/p'); \
+		if [ "$$CURRENT_VERSION" = "$(JULIA_VERSION)" ]; then \
+			echo "Julia $(JULIA_VERSION) already installed ($$CURRENT_VERSION)"; \
+			echo "Checking/updating project environment..."; \
+			mkdir -p $(JULIA_ENV); \
+			julia --project=$(JULIA_ENV) -e '\
+				using Pkg; \
+				if !isfile("$(JULIA_ENV)/Project.toml") || !haskey(Pkg.project().dependencies, "BenchmarkTools"); \
+					println("Setting up BenchmarkTools..."); \
+					Pkg.add("BenchmarkTools"); \
+				else \
+					println("BenchmarkTools already configured"); \
+				end; \
+				Pkg.instantiate(); \
+				println("Project status:"); \
+				Pkg.status()'; \
+			echo "Julia environment ready at $(JULIA_ENV)"; \
+		else \
+			echo "Julia $$CURRENT_VERSION found, but need $(JULIA_VERSION)"; \
+			echo "Installing Julia $(JULIA_VERSION)..."; \
+			$(MAKE) install-julia-fresh; \
+		fi; \
+	else \
+		echo "Julia not found, performing fresh installation..."; \
+		$(MAKE) install-julia-fresh; \
+	fi
+
+# Execute Julia tests.
+test-julia: setup-julia
+	@echo "Running Julia tests..."
+	@"$(JULIAUP_BIN)/julia" --project=$(JULIA_ENV) benchmarks/test.jl
+
+# Clean Julia installations.
+clean-julia:
+	@echo "Removing all Julia installations..."
+	@rm -rf "$(JULIA_DIR)" "$(JULIAUP_DIR)" "$(JULIA_ENV)"
+	@echo "Everything removed. Fresh start available."

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # toqito-bench
 Benchmarking suite for the toqito software package.
+
+## Setup Environments
+
+### Python Environment
+ - to setup a `python 3.10` virtual environment
+```bash
+make setup-python
+```
+- to run tests
+```bash
+make test-python
+```
+- to clean up
+```bash
+make clean-python
+```
+
+### Julia Environment
+ - to setup `Julia 1.10` environment
+```bash
+make setup-julia
+```
+- to run tests
+```bash
+make test-julia
+```
+- to clean up
+```bash
+make clean-julia
+```

--- a/benchmarks/test.jl
+++ b/benchmarks/test.jl
@@ -1,0 +1,98 @@
+using BenchmarkTools
+using LinearAlgebra
+using Random
+
+function fibonacci(n::Int)
+    """Simple fibonacci function for benchmarking."""
+    if n <= 1
+        return n
+    end
+    return fibonacci(n - 1) + fibonacci(n - 2)
+end
+
+function matrix_multiply(size::Int=100)
+    """Matrix multiplication for benchmarking."""
+    Random.seed!(42)  # For reproducible results
+    a = rand(size, size)
+    b = rand(size, size)
+    return a * b
+end
+
+function benchmark_fibonacci()
+    """Benchmark fibonacci function."""
+    println("Benchmarking fibonacci(10)...")
+    result = @benchmark fibonacci(10)
+    println("Result: $(fibonacci(10))")
+    @assert fibonacci(10) == 55
+    display(result)
+    return result
+end
+
+function benchmark_matrix_multiply()
+    """Benchmark matrix multiplication."""
+    println("\nBenchmarking matrix multiplication (50x50)...")
+    result = @benchmark matrix_multiply(50)
+    matrix_result = matrix_multiply(50)
+    println("Result shape: $(size(matrix_result))")
+    @assert size(matrix_result) == (50, 50)
+    display(result)
+    return result
+end
+
+function test_environment_setup()
+    """Test that all required packages are available."""
+    packages = ["BenchmarkTools", "LinearAlgebra", "Random"]
+    missing = String[]
+    
+    for package in packages
+        try
+            eval(Meta.parse("using $package"))
+            println("✓ $package imported successfully")
+        catch e
+            push!(missing, package)
+            println("✗ $package failed to import: $e")
+        end
+    end
+    
+    @assert length(missing) == 0 "Missing packages: $missing"
+end
+
+function run_benchmarks()
+    """Run all benchmark tests."""
+    println("=== Running Julia Benchmarks ===")
+    
+    # Run individual benchmarks
+    fib_result = benchmark_fibonacci()
+    matrix_result = benchmark_matrix_multiply()
+    
+    println("\n=== Benchmark Summary ===")
+    println("Fibonacci(10) median time: $(median(fib_result.times)) ns")
+    println("Matrix multiply (50x50) median time: $(median(matrix_result.times)) ns")
+end
+
+function main()
+    """Main function for direct execution."""
+    println("=== Environment Test ===")
+    test_environment_setup()
+    
+    println("\n=== Demo Calculations ===")
+    println("Fibonacci(10) = $(fibonacci(10))")
+    println("Matrix multiplication (10x10) completed")
+    matrix_multiply(10)
+    
+    println("\nEnvironment setup successful!")
+    println("\nTo run benchmarks, use one of these commands:")
+    println("1. Activate Julia environment first:")
+    println("   julia --project=env/julia-env")
+    println("   julia> include(\"benchmarks/test.jl\")")
+    println("   julia> run_benchmarks()")
+    println("\n2. Or run directly:")
+    println("   julia --project=env/julia-env benchmark/test.jl")
+    println("\n3. Or from activated environment:")
+    println("   julia --project=env/julia-env -e 'include(\"benchmark/test.jl\"); run_benchmarks()'")
+end
+
+# Run main if this file is executed directly
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/benchmarks/test.py
+++ b/benchmarks/test.py
@@ -1,0 +1,70 @@
+import pytest
+import numpy as np
+
+
+def fibonacci(n):
+    """Simple fibonacci function for benchmarking."""
+    if n <= 1:
+        return n
+    return fibonacci(n - 1) + fibonacci(n - 2)
+
+
+def matrix_multiply(size=100):
+    """Matrix multiplication for benchmarking numpy operations."""
+    a = np.random.rand(size, size)
+    b = np.random.rand(size, size)
+    return np.dot(a, b)
+
+
+class TestBenchmarks:
+    """Test class containing benchmark tests."""
+    
+    def test_fibonacci_benchmark(self, benchmark):
+        """Benchmark fibonacci function."""
+        result = benchmark(fibonacci, 10)
+        assert result == 55
+    
+    def test_matrix_multiply_benchmark(self, benchmark):
+        """Benchmark matrix multiplication."""
+        result = benchmark(matrix_multiply, 50)
+        assert result.shape == (50, 50)
+
+
+
+def test_environment_setup():
+    """Test that all required packages are available."""
+    packages = ['numpy', 'pytest']
+    missing = []
+    
+    for package in packages:
+        try:
+            __import__(package)
+            print(f"✓ {package} imported successfully")
+        except ImportError:
+            missing.append(package)
+            print(f"✗ {package} failed to import")
+    
+    assert len(missing) == 0, f"Missing packages: {missing}"
+
+
+def main():
+    """Main function for direct execution."""
+    print("=== Environment Test ===")
+    test_environment_setup()
+    
+    print("\n=== Demo Calculations ===")
+    print(f"Fibonacci(10) = {fibonacci(10)}")
+    print(f"Matrix multiplication (10x10) completed")
+    matrix_multiply(10)
+    
+    print("\nEnvironment setup successful!")
+    print("\nTo run benchmarks, use one of these commands:")
+    print("1. Activate virtual environment first:")
+    print("   source env/python-env/bin/activate")
+    print("   pytest benchmark/test.py")
+    print("\n2. Or run directly without activation:")
+    print("   env/python-env/bin/python -m pytest benchmark/test.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "toqito-bench"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ name = "toqito-bench"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = []


### PR DESCRIPTION
Aimed towards resolving https://github.com/vprusso/toqito-bench/issues/2

- [x] added setup instructions for `python` environment in `README.md`
- [x] added setup instructions for `julia` environment in `README.md`
- [x] added setup instructions for `MATLAB` environment in `README.md`

---
running 
```bash 
make test-python
```
returns with a completed test output and some instructions to use the `python` virtual environment 
```bash
...
Running tests...
=== Environment Test ===
✓ numpy imported successfully
✓ pytest imported successfully

=== Demo Calculations ===
Fibonacci(10) = 55
Matrix multiplication (10x10) completed

Environment setup successful!

To run benchmarks, use one of these commands:
1. Activate virtual environment first:
   source env/python-env/bin/activate
   pytest benchmark/test.py

2. Or run directly without activation:
   env/python-env/bin/python -m pytest benchmark/test.py
Tests completed!
```
---
similarly,
```bash 
make test-julia
```
returns

```bash
...
=== Environment Test ===
✓ BenchmarkTools imported successfully
✓ LinearAlgebra imported successfully
✓ Random imported successfully

=== Demo Calculations ===
Fibonacci(10) = 55
Matrix multiplication (10x10) completed

Environment setup successful!

To run benchmarks, use one of these commands:
1. Activate Julia environment first:
   julia --project=env/julia-env
   julia> include("benchmarks/test.jl")
   julia> run_benchmarks()

2. Or run directly:
   julia --project=env/julia-env benchmark/test.jl

3. Or from activated environment:
   julia --project=env/julia-env -e 'include("benchmark/test.jl"); run_benchmarks()'
```

