### PR TITLE
add benchmarks in ketjl

### DIFF
--- a/scripts/benchmark_ketjl.jl
+++ b/scripts/benchmark_ketjl.jl
@@ -149,3 +149,29 @@ for (sys, id) in zip(sys_list, ids)
         sys_group[key] = @benchmarkable partial_trace($input_mat, $sys, $dims)
     end
 end
+
+
+# ---- random_density_matrix ---- # 
+SUITE["TestRandomUnitaryBenchmarks"] = BenchmarkGroup()
+SUITE["TestRandomUnitaryBenchmarks"]["test_bench__random_unitary__vary__dim"] = BenchmarkGroup()
+SUITE["TestRandomUnitaryBenchmarks"]["test_bench__random_unitary__vary__is_real"] = BenchmarkGroup()
+
+"""Benchmark `random_unitary` with varying matrix dimensions."""
+dim_group = SUITE["TestRandomUnitaryBenchmarks"]["test_bench__random_unitary__vary__dim"]
+dims = [4, 16, 64, 256, 1024]
+
+for dim in dims
+    key = "test_bench__random_unitary__vary__dim[$dim]"
+    dim_group[key] = @benchmarkable random_unitary($dim)
+end
+
+"""Benchmark `random_unitary` for both real and complex-valued matrices."""
+type_group = SUITE["TestRandomUnitaryBenchmarks"]["test_bench__random_unitary__vary__is_real"]
+types = [Float64, ComplexF64]
+
+for T in types
+    label = !(T <: Complex) ? "True" : "False" 
+    key = "test_bench__random_unitary__vary__is_real[$label]"
+    dim = 64
+    type_group[key] = @benchmarkable random_unitary($T, $dim)
+end

--- a/scripts/benchmark_ketjl.jl
+++ b/scripts/benchmark_ketjl.jl
@@ -151,7 +151,7 @@ for (sys, id) in zip(sys_list, ids)
 end
 
 
-# ---- random_density_matrix ---- # 
+# ---- random_unitary ---- # 
 SUITE["TestRandomUnitaryBenchmarks"] = BenchmarkGroup()
 SUITE["TestRandomUnitaryBenchmarks"]["test_bench__random_unitary__vary__dim"] = BenchmarkGroup()
 SUITE["TestRandomUnitaryBenchmarks"]["test_bench__random_unitary__vary__is_real"] = BenchmarkGroup()
@@ -178,7 +178,6 @@ end
 
 
 # ---- random_povm ---- # 
-
 SUITE["TestRandomPOVMBenchmarks"] = BenchmarkGroup()
 SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__dim"] = BenchmarkGroup()
 SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__num_inputs"] = BenchmarkGroup()
@@ -187,11 +186,12 @@ SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__dim_num_inputs
 
 """Benchmark `random_povm` with varying POVM dimensions."""
 dim_group = SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__dim"]
+
+
 for dim in [4, 16, 64, 256]
+    key = "test_bench__random_povm__vary__dim[$dim]"
     num_inputs = 4
     num_outputs = 4
-
-    key = "test_bench__random_povm__vary__dim[$dim]"
     dim_group[key] = @benchmarkable begin
         povms = [random_povm($dim, $num_outputs, $dim) for _ in 1:$num_inputs]
         povm_array = Array{ComplexF64, 4}(undef, $dim, $dim, $num_inputs, $num_outputs)
@@ -290,7 +290,7 @@ for dim in dims
     rho_group[key] = @benchmarkable begin
         input_mat = randn(ComplexF64, $dim, $dim)
         input_mat = input_mat * adjoint(input_mat)
-        rho = input_mat/ tr(input_mat)
+        rho = input_mat / tr(input_mat)
         h = entropy(rho)
         @assert isa(h, Number) && h >= 0
     end
@@ -304,6 +304,7 @@ SUITE["TestAmplitudeDampingBenchmarks"]["test_bench__amplitude_damping__vary__in
 bench_group = SUITE["TestAmplitudeDampingBenchmarks"]["test_bench__amplitude_damping__vary__input_mat_gamma_prob"]
 
 configs = [
+    # input_mat present, gamma, prob
     ("False", 0.0, 0.0),
     ("False", 0.1, 0.5),
     ("False", 0.5, 0.5),
@@ -339,7 +340,6 @@ end
 
 
 # ---- channel_bit_flip ---- # 
-
 SUITE["TestBitflipBenchmarks"] = BenchmarkGroup()
 SUITE["TestBitflipBenchmarks"]["test_bench__bitflip__vary__input_mat_prob"] = BenchmarkGroup()
 
@@ -382,7 +382,6 @@ end
 
 
 # ---- ket ---- # 
-
 SUITE["TestBasisBenchmarks"] = BenchmarkGroup()
 SUITE["TestBasisBenchmarks"]["test_bench__basis__vary__dim"] = BenchmarkGroup()
 
@@ -398,12 +397,9 @@ end
 
 
 # ---- permute_systems---- #
-
 SUITE["TestPermuteSystemBenchmarks"] = BenchmarkGroup()
 SUITE["TestPermuteSystemBenchmarks"]["test_bench__permute_systems__vary__dim_perm"] = BenchmarkGroup()
 SUITE["TestPermuteSystemBenchmarks"]["test_bench__permute_systems__vary__vector_input"] = BenchmarkGroup()
-
-
 
 dim_perm_group = SUITE["TestPermuteSystemBenchmarks"]["test_bench__permute_systems__vary__dim_perm"]
 dim_perm_cases = [
@@ -437,7 +433,7 @@ vec_cases = [
 ]
 
 for (size, dims, perm) in vec_cases
-    perm_jl = [ p+1 for p in perm]
+    perm_jl = [p+1 for p in perm]
     key = "test_bench__permute_systems__vary__vector_input[$size-$dims-$perm]"
     vec_group[key] = @benchmarkable begin
         vec = randn(ComplexF64, $size)
@@ -447,7 +443,6 @@ for (size, dims, perm) in vec_cases
 end
 
 # ---- choi---- #
-
 SUITE["TestKraustoChoiBenchmarks"] = BenchmarkGroup()
 SUITE["TestKraustoChoiBenchmarks"]["test_bench__choi_representation__vary__kraus_ops"] = BenchmarkGroup()
 SUITE["TestKraustoChoiBenchmarks"]["test_bench__choi_representation__param__sys"] = BenchmarkGroup()
@@ -512,20 +507,29 @@ for n in (2, 4, 8)
 end
 
 # ---- permutation_matrix---- #
-
 SUITE["TestPermutationOperatorBenchmarks"] = BenchmarkGroup()
 
 dim_perm_group = SUITE["TestPermutationOperatorBenchmarks"]["test_bench__permutation_operator__vary__dim_perm"] = BenchmarkGroup()
 
 cases = [
-    (2, [1, 0]),
-    (2, [1, 2, 0]),
-    (2, [1, 2, 0, 3]),
-    (2, [1, 2, 0, 3, 4]),
-    (2, [1, 2, 5, 0, 3, 4]),
-    (16, [1, 0]),
-    (16, [1, 2, 0]),
-    (8, [1, 2, 0, 3]),
+    # 2 subsystems
+    (2, [1, 0]),  # 4x4 matrix (swap)
+    (16, [1, 0]), # 256x256 matrix (swap)
+
+    # 3 subsystems
+    (2, [1, 2, 0]), # 8x8 matrix (cycle)
+
+    # 4 subsystems
+    (2, [1, 2, 0, 3]), # 16x16 matrix
+
+    # 5 subsystems
+    (2, [1, 2, 0, 3, 4]), # 32x32 matrix
+
+    # 6 subsystems
+    (2, [1, 2, 5, 0, 3, 4]), # 64x64 matrix (complex shuffle)
+    
+    # (16, [1, 2, 0]),
+    # (8, [1, 2, 0, 3]),
 ]
 
 for (dim, perm) in cases

--- a/scripts/benchmark_ketjl.jl
+++ b/scripts/benchmark_ketjl.jl
@@ -512,3 +512,60 @@ for n in (2, 4, 8)
 end
 
 # ---- permutation_matrix---- #
+
+SUITE["TestPermutationOperatorBenchmarks"] = BenchmarkGroup()
+
+dim_perm_group = SUITE["TestPermutationOperatorBenchmarks"]["test_bench__permutation_operator__vary__dim_perm"] = BenchmarkGroup()
+
+cases = [
+    (2, [1, 0]),
+    (2, [1, 2, 0]),
+    (2, [1, 2, 0, 3]),
+    (2, [1, 2, 0, 3, 4]),
+    (2, [1, 2, 5, 0, 3, 4]),
+    (16, [1, 0]),
+    (16, [1, 2, 0]),
+    (8, [1, 2, 0, 3]),
+]
+
+for (dim, perm) in cases
+    perm_jl = [p+1 for p in perm]
+    local key = "test_bench__permutation_matrix__vary__dim_perm[$dim-$perm]"
+    dim_perm_group[key] = @benchmarkable begin
+        p = permutation_matrix(ComplexF64, $dim, $perm_jl)
+        @assert size(p) == ($dim^(length($perm_jl)), $dim^(length($perm_jl)))
+    end
+end
+
+
+# ---- apply_map ---- #
+
+# SUITE["TestApplyChannelBenchmarks"] = BenchmarkGroup()
+# SUITE["TestApplyChannelBenchmarks"]["test_bench__apply_channel__vary__phi_op"] = BenchmarkGroup()
+
+# phi_op_group = SUITE["TestApplyChannelBenchmarks"]["test_bench__apply_channel__vary__phi_op"]
+# cases = [
+#     ("kraus", 4),
+#     ("kraus", 16),
+#     ("kraus", 64),
+#     ("kraus", 256),
+#     # ("choi", 2),
+#     # ("choi", 4),
+#     # ("choi", 16),
+#     # ("choi", 64),
+#     # ("choi", (4, 16)),
+#     # ("choi", (32, 64)),
+# ]
+
+# for (phi_op_type, dim) in cases
+#     key = "test_bench__applymap__vary__phi_op[$phi_op_type-$(dim)]"
+#     if phi_op_type == "kraus"
+#         d = dim
+#         input_mat = randn(ComplexF64, d, d)
+#         K = [randn(ComplexF64, d, d) for _ in 1:4]
+#         phi_op_group[key] = @benchmarkable begin
+#             result = applymap(K, $input_mat)
+#             @assert size(result) == ($d, $d)
+#         end
+#     end
+# end

--- a/scripts/benchmark_ketjl.jl
+++ b/scripts/benchmark_ketjl.jl
@@ -379,3 +379,69 @@ for (input_mat, prob) in cases
         end
     end
 end
+
+
+# ---- ket ---- # 
+
+SUITE["TestBasisBenchmarks"] = BenchmarkGroup()
+SUITE["TestBasisBenchmarks"]["test_bench__basis__vary__dim"] = BenchmarkGroup()
+
+dim_group = SUITE["TestBasisBenchmarks"]["test_bench__basis__vary__dim"]
+
+for dim in [4, 16, 64, 256]
+    key = "test_bench__basis__vary__dim[$dim]"
+    dim_group[key] = @benchmarkable begin
+        v = ket(Float64, 3, $dim)
+        @assert length(v) == $dim
+    end
+end
+
+
+# ---- permute_systems---- #
+
+SUITE["TestPermuteSystemBenchmarks"] = BenchmarkGroup()
+SUITE["TestPermuteSystemBenchmarks"]["test_bench__permute_systems__vary__dim_perm"] = BenchmarkGroup()
+SUITE["TestPermuteSystemBenchmarks"]["test_bench__permute_systems__vary__vector_input"] = BenchmarkGroup()
+
+
+
+dim_perm_group = SUITE["TestPermuteSystemBenchmarks"]["test_bench__permute_systems__vary__dim_perm"]
+dim_perm_cases = [
+    ([2, 2], [1, 0]),
+    ([4, 4], [1, 0]),
+    ([8, 8], [1, 0]),
+    ([2, 2, 2], [1, 2, 0]),
+    ([4, 4, 4], [2, 0, 1]),
+    ([2, 2, 2, 2], [3, 2, 1, 0]),
+    ([4, 4, 4, 4], [3, 0, 2, 1]),
+]
+
+for (dims, perm) in dim_perm_cases
+    size = prod(dims)
+    perm_jl = [p+1 for p in perm]
+    key = "test_bench__permute_systems__vary__dim_perm[$dims-$perm]"
+    dim_perm_group[key] = @benchmarkable begin
+        mat = randn(ComplexF64, $size, $size)
+        result = permute_systems(mat, $perm_jl, $dims)
+    end
+end
+    
+vec_group = SUITE["TestPermuteSystemBenchmarks"]["test_bench__permute_systems__vary__vector_input"]
+
+vec_cases = [
+    (4, [2, 2], [1, 0]),
+    (8, [2, 2, 2], [1, 2, 0]),
+    (16, [4, 4], [1, 0]),
+    (64, [4, 4, 4], [2, 1, 0]),
+    (256, [16, 16], [1, 0]),
+]
+
+for (size, dims, perm) in vec_cases
+    perm_jl = [ p+1 for p in perm]
+    key = "test_bench__permute_systems__vary__vector_input[$size-$dims-$perm]"
+    vec_group[key] = @benchmarkable begin
+        vec = randn(ComplexF64, $size)
+        result = permute_systems(vec, $perm_jl, $dims)
+        @assert length(result) == $size
+    end
+end

--- a/scripts/benchmark_ketjl.jl
+++ b/scripts/benchmark_ketjl.jl
@@ -445,3 +445,45 @@ for (size, dims, perm) in vec_cases
         @assert length(result) == $size
     end
 end
+
+# ---- choi---- #
+
+SUITE["TestKraustoChoiBenchmarks"] = BenchmarkGroup()
+SUITE["TestKraustoChoiBenchmarks"]["test_bench__choi_representation__vary__kraus_ops"] = BenchmarkGroup()
+SUITE["TestKraustoChoiBenchmarks"]["test_bench__choi_representation__param__sys"] = BenchmarkGroup()
+
+choi_group = SUITE["TestKraustoChoiBenchmarks"]["test_bench__choi_representation__vary__kraus_ops"]
+
+# (dim, num_ops, cp)
+cases = [
+    (2, 4, true),
+    (2, 32, true),
+    (4, 4, true),
+    (4, 32, true),
+    (16, 4, true),
+    (16, 32, true),
+    # non-CP cases are NOT supported in ketjl.
+]
+
+for (dim, num_ops, cp) in cases
+    key = "test_bench__choi_representation__vary__kraus_ops[$dim-$num_ops-True]"
+    if cp
+        choi_group[key] = @benchmarkable begin
+            K = [randn(ComplexF64, $dim, $dim) for _ in 1:$num_ops]
+            C = choi(K)
+            @assert size(C) == ($dim^2, $dim^2)
+        end
+    end
+end
+
+sys_group = SUITE["TestKraustoChoiBenchmarks"]["test_bench__choi_representation__param__sys"]
+
+# Only sys==2 is supported,
+key = "test_bench__choi_representation__param__sys[2]"
+sys_group[key] = @benchmarkable begin
+    dim = 16
+    num_ops = 4
+    K = [randn(ComplexF64, dim, dim) for _ in 1:num_ops]
+    C = choi(K)
+    @assert size(C) == (dim^2, dim^2)
+end

--- a/scripts/benchmark_ketjl.jl
+++ b/scripts/benchmark_ketjl.jl
@@ -175,3 +175,77 @@ for T in types
     dim = 64
     type_group[key] = @benchmarkable random_unitary($T, $dim)
 end
+
+
+# ---- random_povm ---- # 
+
+SUITE["TestRandomPOVMBenchmarks"] = BenchmarkGroup()
+SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__dim"] = BenchmarkGroup()
+SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__num_inputs"] = BenchmarkGroup()
+SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__num_outputs"] = BenchmarkGroup()
+SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__dim_num_inputs_num_outputs"] = BenchmarkGroup()
+
+"""Benchmark `random_povm` with varying POVM dimensions."""
+dim_group = SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__dim"]
+for dim in [4, 16, 64, 256]
+    num_inputs = 4
+    num_outputs = 4
+
+    key = "test_bench__random_povm__vary__dim[$dim]"
+    dim_group[key] = @benchmarkable begin
+        povms = [random_povm($dim, $num_outputs, $dim) for _ in 1:$num_inputs]
+        povm_array = Array{ComplexF64, 4}(undef, $dim, $dim, $num_inputs, $num_outputs)
+        for i in 1:$num_inputs, j in 1:$num_outputs
+            povm_array[:, :, i, j] = povms[i][j].data
+        end
+        @assert size(povm_array) == ($dim, $dim, $num_inputs, $num_outputs)
+    end
+end
+
+"""Benchmark `random_povm` with varying number of measurement inputs."""
+input_group = SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__num_inputs"]
+for num_inputs in [4, 16, 64, 256]
+    dim = 4
+    num_outputs = 4
+    key = "test_bench__random_povm__vary__num_inputs[$num_inputs]"
+    input_group[key] = @benchmarkable begin
+        povms = [random_povm($dim, $num_outputs, $dim) for _ in 1:$num_inputs]
+        povm_array = Array{ComplexF64, 4}(undef, $dim, $dim, $num_inputs, $num_outputs)
+        for i in 1:$num_inputs, j in 1:$num_outputs
+            povm_array[:, :, i, j] = povms[i][j].data
+        end
+        @assert size(povm_array) == ($dim, $dim, $num_inputs, $num_outputs)
+    end
+end
+
+"""Benchmark `random_povm` with varying number of measurement outputs."""
+outputs_group = SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__num_outputs"]
+for num_outputs in [4, 16, 64, 256]
+    dim = 4
+    num_inputs = 4
+    key = "test_bench__random_povm__vary__num_outputs[$num_outputs]"
+    outputs_group[key] = @benchmarkable begin
+        povms = [random_povm($dim, $num_outputs, $dim) for _ in 1:$num_inputs]
+        povm_array = Array{ComplexF64, 4}(undef, $dim, $dim, $num_inputs, $num_outputs)
+        for i in 1:$num_inputs, j in 1:$num_outputs
+            povm_array[:, :, i, j] = povms[i][j].data
+        end
+        @assert size(povm_array) == ($dim, $dim, $num_inputs, $num_outputs)
+    end
+end
+
+"""Benchmark `random_povm` with varying combinations of dimensions, inputs, and outputs."""
+combo_group = SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__dim_num_inputs_num_outputs"]
+for (dim, num_inputs, num_outputs) in [
+        (4, 4, 4), (4, 8, 8), (8, 4, 8), (8, 8, 4), (8, 8, 8), (16, 16, 16)
+    ]
+    key = "test_bench__random_povm__vary__dim_num_inputs_num_outputs[$dim,$num_inputs,$num_outputs]"
+    combo_group[key] = @benchmarkable begin
+        povms = [random_povm($dim, $num_outputs, $dim) for _ in 1:$num_inputs]
+        povm_array = Array{ComplexF64, 4}(undef, $dim, $dim, $num_inputs, $num_outputs)
+        for i in 1:$num_inputs, j in 1:$num_outputs
+            povm_array[:, :, i, j] = povms[i][j].data
+        end
+        @assert size(povm_array) == ($dim, $dim, $num_inputs, $num_outputs)
+    end
+end

--- a/scripts/benchmark_ketjl.jl
+++ b/scripts/benchmark_ketjl.jl
@@ -239,7 +239,7 @@ combo_group = SUITE["TestRandomPOVMBenchmarks"]["test_bench__random_povm__vary__
 for (dim, num_inputs, num_outputs) in [
         (4, 4, 4), (4, 8, 8), (8, 4, 8), (8, 8, 4), (8, 8, 8), (16, 16, 16)
     ]
-    key = "test_bench__random_povm__vary__dim_num_inputs_num_outputs[$dim,$num_inputs,$num_outputs]"
+    key = "test_bench__random_povm__vary__dim_num_inputs_num_outputs[$dim-$num_inputs-$num_outputs]"
     combo_group[key] = @benchmarkable begin
         povms = [random_povm($dim, $num_outputs, $dim) for _ in 1:$num_inputs]
         povm_array = Array{ComplexF64, 4}(undef, $dim, $dim, $num_inputs, $num_outputs)
@@ -247,5 +247,31 @@ for (dim, num_inputs, num_outputs) in [
             povm_array[:, :, i, j] = povms[i][j].data
         end
         @assert size(povm_array) == ($dim, $dim, $num_inputs, $num_outputs)
+    end
+end
+
+
+# ---- trace_norm ---- # 
+SUITE["TestTraceNormBenchmarks"] = BenchmarkGroup()
+SUITE["TestTraceNormBenchmarks"]["test_bench__random_povm__vary__dim"] = BenchmarkGroup()
+
+"""Benchmark `trace_norm` with varying matrix dimensions and square/non-square shapes."""
+dim_group = SUITE["TestTraceNormBenchmarks"]["test_bench__trace_norm__vary__rho"]
+dim_cases = [(4, "square"),(16, "square"),(64, "square"),(128, "square"),(25, "not_square"),(100, "not_square")]
+
+for (dim, is_square) in dim_cases
+    key = "test_bench__trace_norm__vary__rho[$dim-$is_square]"
+    if is_square == "square"
+        dim_group[key] = @benchmarkable begin
+            rho = randn(ComplexF64, $dim, $dim)
+            val = trace_norm(rho)
+            @assert !isnothing(val)
+        end
+    else
+        dim_group[key] = @benchmarkable begin
+            rho = randn(ComplexF64, $dim, 2*$dim)
+            val = trace_norm(rho)
+            @assert !isnothing(val)
+        end
     end
 end

--- a/scripts/benchmark_ketjl.jl
+++ b/scripts/benchmark_ketjl.jl
@@ -487,3 +487,28 @@ sys_group[key] = @benchmarkable begin
     C = choi(K)
     @assert size(C) == (dim^2, dim^2)
 end
+
+# ---- pauli ---- #
+SUITE["TestPauliBenchmarks"] = BenchmarkGroup()
+SUITE["TestPauliBenchmarks"]["test_bench__pauli__vary__ind"] = BenchmarkGroup()
+
+pauli_group = SUITE["TestPauliBenchmarks"]["test_bench__pauli__vary__ind"]
+
+for j in 0:3
+    key1 = "test_bench__pauli__vary__ind[int-$j]"
+    pauli_group[key1] = @benchmarkable begin
+        M = pauli($j)
+        @assert size(M) == (2,2)
+    end
+end
+
+for n in (2, 4, 8)
+    key2 = "test_bench__pauli__vary__ind[list-$n]"
+    inds = rand(0:3, n)
+    pauli_group[key2] = @benchmarkable begin
+        M = pauli($inds)
+        @assert size(M) == (2^$n, 2^$n)
+    end
+end
+
+# ---- permutation_matrix---- #

--- a/scripts/benchmark_ketjl.jl
+++ b/scripts/benchmark_ketjl.jl
@@ -275,3 +275,23 @@ for (dim, is_square) in dim_cases
         end
     end
 end
+
+# ---- entropy ---- # 
+SUITE["TestVonNeumannEntropyBenchmarks"] = BenchmarkGroup()
+SUITE["TestVonNeumannEntropyBenchmarks"]["test_bench__von_neumann_entropy__vary__rho"] = BenchmarkGroup()
+
+"""Benchmark `von_neumann_entropy` by varying the dimension of the density matrix."""
+rho_group = SUITE["TestVonNeumannEntropyBenchmarks"]["test_bench__von_neumann_entropy__vary__rho"]
+dims = [4, 16, 32, 64, 128, 256]
+
+for dim in dims
+    key = "test_bench__von_neumann_entropy__vary__rho[$dim]"
+
+    rho_group[key] = @benchmarkable begin
+        input_mat = randn(ComplexF64, $dim, $dim)
+        input_mat = input_mat * adjoint(input_mat)
+        rho = input_mat/ tr(input_mat)
+        h = entropy(rho)
+        @assert isa(h, Number) && h >= 0
+    end
+end


### PR DESCRIPTION
| toqito                          | QuTiPy     | ketjl
|--------------------|-----------------|----------|
 | partial_trace       | partial_trace        | partial_trace
 |random_density_matrix | random_density_matrix |
| random_unitary | RandomUnitary | random_unitary|
| random_povm| | random_povm|
| random_psd_operator | random_PSD_operator |
| trace_distance | norm_trace_dist |
| trace_norm | trace_norm | trace_norm|
| log_negativity| log_negativity|
| von_neumann_entropy| entropy| entropy|
| natural_representation| natural_representation|
| amplitude_damping| amplitude_damping_channel| channel_amplitude_damping_generalized|
| bitflip| bit_flip_channel| channel_bit_flip|
| dephasing| dephasing_channel|
 | basis       |   ket     | ket |
 | is_positive_semidefinite ||
 | swap ||
 | swap_operator | SWAP|
 | to_density_matrix ||
 | permute_systems | syspermute| permute_systems
  | kraus_to_choi | choi_representation| choi|
  | pauli | generate_nQubit_Pauli | pauli |
  | permutation_operator | permute_tensor_factors| permutation_matrix|
  | apply_channel | apply_channel|
  | partial_transpose | partial_transpose|
  | random_povm| |